### PR TITLE
Don't be strict by default; support more fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,8 @@ serde_json = "1.0"
 
 [dev_dependencies]
 chrono = "*"
+
+[features]
+default = []
+deny_unknown_fields = []
+strict = ["deny_unknown_fields"]

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -1,27 +1,27 @@
 use serde_json;
 
 #[derive(Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
 pub struct Hangouts {
     pub conversations: Vec<Conversation>,
 }
 
 #[derive(Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
 pub struct Conversation {
     #[serde(rename="conversation")] pub header: ConversationHeader,
     pub events: Vec<Event>,
 }
 
 #[derive(Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
 pub struct ConversationHeader {
     pub conversation_id: ConversationId,
     #[serde(rename="conversation")] pub details: ConversationDetails,
 }
 
 #[derive(Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
 pub struct ConversationDetails {
     pub id: ConversationId,
     #[serde(rename="type")] pub typ: String,
@@ -40,13 +40,13 @@ pub struct ConversationDetails {
 }
 
 #[derive(Deserialize, Debug, PartialEq)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
 pub struct ConversationId {
     pub id: String,
 }
 
 #[derive(Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
 pub struct SelfConversationState {
     pub self_read_state: ReadState,
     pub status: String,
@@ -63,21 +63,21 @@ pub struct SelfConversationState {
 }
 
 #[derive(Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
 pub struct ReadState {
     pub participant_id: ParticipantId,
     pub latest_read_timestamp: String,
 }
 
 #[derive(Deserialize, Debug, PartialEq, Eq, Hash, Clone)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
 pub struct ParticipantId {
     pub gaia_id: String,
     pub chat_id: String,
 }
 
 #[derive(Deserialize, Debug, Clone)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
 pub struct ParticipantData {
     pub id: ParticipantId,
     pub fallback_name: Option<String>,
@@ -90,7 +90,7 @@ pub struct ParticipantData {
 }
 
 #[derive(Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
 pub struct Event {
     #[serde(flatten)] pub header: EventHeader,
     #[serde(flatten)] pub data: EventData,
@@ -98,7 +98,7 @@ pub struct Event {
 }
 
 #[derive(Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
 pub struct EventHeader {
     pub conversation_id: ConversationId,
     pub sender_id: ParticipantId,
@@ -112,7 +112,7 @@ pub struct EventHeader {
 }
 
 #[derive(Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
 pub struct SelfEventState {
     pub user_id: ParticipantId,
     pub client_generated_id: Option<String>,
@@ -120,14 +120,14 @@ pub struct SelfEventState {
 }
 
 #[derive(Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
 pub enum NotificationLevel {
     #[serde(rename="QUIET")] Quiet,
     #[serde(rename="RING")] Ring,
 }
 
 #[derive(Deserialize, Debug)]
-//#[serde(deny_unknown_fields)]
+//#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
 pub enum EventData {
     #[serde(rename="chat_message")]
     ChatMessage {
@@ -150,7 +150,7 @@ pub enum EventData {
 }
 
 #[derive(Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
 pub struct ChatSegments {
     #[serde(default, rename="segment")] pub segments: Vec<ChatSegment>,
     #[serde(default, rename="attachment")] pub attachments: Vec<AttachmentSegment>,
@@ -158,7 +158,7 @@ pub struct ChatSegments {
 
 #[derive(Deserialize, Debug)]
 #[serde(tag="type")]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
 pub enum ChatSegment {
     #[serde(rename="TEXT")]
     Text {
@@ -186,14 +186,14 @@ pub struct Annotation {
 }
 
 #[derive(Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
 pub struct LinkData {
     pub link_target: String,
     pub display_url: Option<String>,
 }
 
 #[derive(Deserialize, Debug, Default)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
 pub struct Formatting {
     #[serde(default)] pub bold: bool,
     #[serde(default)] pub italics: bool,
@@ -202,14 +202,14 @@ pub struct Formatting {
 }
 
 #[derive(Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
 pub struct AttachmentSegment {
     pub embed_item: EmbedItem,
     pub id: String,
 }
 
 #[derive(Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
 pub struct EmbedItem {
     pub id: Option<String>,
     pub plus_photo: Option<PlusPhoto>,
@@ -219,7 +219,7 @@ pub struct EmbedItem {
 }
 
 #[derive(Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
 pub struct PlusPhoto {
     pub album_id: String,
     pub media_type: String,
@@ -233,7 +233,7 @@ pub struct PlusPhoto {
 }
 
 #[derive(Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
 pub struct Thumbnail {
     pub height_px: u64,
     pub width_px: u64,
@@ -242,7 +242,7 @@ pub struct Thumbnail {
 }
 
 #[derive(Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
 pub struct PlaceV2 {
     pub url: String,
     pub name: Option<String>,
@@ -255,14 +255,14 @@ pub struct PlaceV2 {
 }
 
 #[derive(Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
 pub struct Address {
     #[serde(rename="type", default)] pub types: Vec<String>,
     pub postal_address_v2: PostalAddressV2,
 }
 
 #[derive(Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
 pub struct PostalAddressV2 {
     pub name: Option<String>,
     pub street_address: Option<String>,
@@ -273,21 +273,21 @@ pub struct PostalAddressV2 {
 }
 
 #[derive(Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
 pub struct Geo {
     #[serde(rename="type", default)] pub types: Vec<String>,
     pub geo_coordinates_v2: GeoCoordinatesV2,
 }
 
 #[derive(Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
 pub struct GeoCoordinatesV2 {
     pub latitude: f64,
     pub longitude: f64,
 }
 
 #[derive(Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
 pub struct RepresentativeImage {
     #[serde(rename="type")] pub types: Vec<String>,
     pub id: String,
@@ -295,7 +295,7 @@ pub struct RepresentativeImage {
 }
 
 #[derive(Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
 pub struct ImageObjectV2 {
     pub url: String,
     pub width: Option<String>,
@@ -303,7 +303,7 @@ pub struct ImageObjectV2 {
 }
 
 #[derive(Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
 pub struct ThingV2 {
     pub url: String,
     pub name: Option<String>,
@@ -312,7 +312,7 @@ pub struct ThingV2 {
 
 #[derive(Deserialize, Debug)]
 #[serde(tag="event_type")]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
 pub enum HangoutEvent {
     #[serde(rename="START_HANGOUT")] StartHangout,
     #[serde(rename="END_HANGOUT")] EndHangout {

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -36,6 +36,7 @@ pub struct ConversationDetails {
     pub fork_on_external_invite: bool,
     pub network_type: Vec<String>,
     pub force_history_state: String,
+    pub conversation_ttl_days: Option<String>,
     pub group_link_sharing_status: String
 }
 
@@ -85,6 +86,7 @@ pub struct ParticipantData {
     pub participant_type: Option<String>,
     pub new_invitation_status: Option<String>,
     pub in_different_customer_as_requester: Option<bool>,
+    pub is_anonymous_phone: Option<bool>,
     pub domain_id: Option<String>,
     pub phone_number: Option<serde_json::Value>, // TODO
 }
@@ -135,11 +137,17 @@ pub enum EventData {
         annotation: Option<Vec<Annotation>>,
     },
 
+    #[serde(rename="conversation_rename")]
+    ConversationRename {
+        old_name: String,
+        new_name: String,
+    },
+
     #[serde(rename="hangout_event")]
     HangoutEvent {
         #[serde(flatten)] data: HangoutEvent,
-        media_type: String,
-        participant_id: Vec<ParticipantId>,
+        media_type: Option<String>,
+        #[serde(default)] participant_id: Vec<ParticipantId>,
     },
 
     #[serde(rename="membership_change")]
@@ -213,6 +221,7 @@ pub struct AttachmentSegment {
 pub struct EmbedItem {
     pub id: Option<String>,
     pub plus_photo: Option<PlusPhoto>,
+    pub plus_audio_v2: Option<PlusAudioV2>,
     pub place_v2: Option<PlaceV2>,
     pub thing_v2: Option<ThingV2>,
     #[serde(rename="type")] pub types: Vec<String>,
@@ -223,8 +232,8 @@ pub struct EmbedItem {
 pub struct PlusPhoto {
     pub album_id: String,
     pub media_type: String,
-    pub original_content_url: String,
-    pub owner_obfuscated_id: String,
+    pub original_content_url: Option<String>,
+    pub owner_obfuscated_id: Option<String>,
     pub photo_id: String,
     pub stream_id: Vec<String>,
     pub thumbnail: Thumbnail,
@@ -252,6 +261,18 @@ pub struct PlaceV2 {
     pub place_id: Option<String>,
     pub cluster_id: Option<String>,
     pub reference_id: Option<String>,
+}
+
+#[derive(Deserialize, Debug)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+pub struct PlusAudioV2 {
+    pub album_id: String,
+    pub duration: String,
+    pub embed_url: String,
+    pub media_key: String,
+    pub owner_obfuscated_id: Option<String>,
+    pub photo_id: String,
+    pub url: String,
 }
 
 #[derive(Deserialize, Debug)]


### PR DESCRIPTION
Adds an optional feature `strict` that enables stricter serde deserialization options like `deny_unknown_fields`.

Also adds support for more complex data types (variants, fields, etc.).